### PR TITLE
fix: correct end column calculation for highlight precision

### DIFF
--- a/lua/tidal-highlight/source_map.lua
+++ b/lua/tidal-highlight/source_map.lua
@@ -34,7 +34,7 @@ function M.generate(bufnr, range)
           },
           ["end"] = {
             line = literal.range.start.line,
-            col = literal.range.start.col + 1 + token.relative_range["end"],
+            col = literal.range.start.col + 1 + token.relative_range["end"] + 1,
           },
         }
 


### PR DESCRIPTION
- Add +1 to end column in source_map coordinate translation
- Fixes highlights ending one character short of tokens
- Resolves issue where 'bd sn' missed closing quote and 'kick snare' missed 'e'